### PR TITLE
Don't panic

### DIFF
--- a/src/blur.rs
+++ b/src/blur.rs
@@ -90,12 +90,16 @@ fn box_blur_vert(backbuf: &[[u8;3]], frontbuf: &mut [[u8;3]], width: usize, heig
             }
         };
 
-        // TODO: not linear complexity, fix this
-        for j in 0..blur_radius {
-            let bb = get_bottom(ti + j * width);
+        for j in 0..min(blur_radius, height) {
+            let bb = backbuf[ti + j * width];
             val_r += bb[0] as isize;
             val_g += bb[1] as isize;
             val_b += bb[2] as isize;
+        }
+        if blur_radius > height {
+            val_r += (blur_radius - height) as isize * isize::from(lv[0]);
+            val_g += (blur_radius - height) as isize * isize::from(lv[1]);
+            val_b += (blur_radius - height) as isize * isize::from(lv[2]);
         }
 
         for _ in 0..min(height, blur_radius + 1) {
@@ -127,7 +131,7 @@ fn box_blur_vert(backbuf: &[[u8;3]], frontbuf: &mut [[u8;3]], width: usize, heig
             }
 
             for _ in 0..min(height - blur_radius - 1, blur_radius) {
-                let bb = get_bottom(li); li += width;
+                let bb = get_top(li); li += width;
 
                 val_r += lv[0] as isize - bb[0] as isize;
                 val_g += lv[1] as isize - bb[1] as isize;
@@ -182,13 +186,18 @@ fn box_blur_horz(backbuf: &[[u8;3]], frontbuf: &mut [[u8;3]], width: usize, heig
             }
         };
 
-        // TODO: not linear complexity, fix this
-        for j in 0..blur_radius {
-            let bb = get_right(ti + j); // VERTICAL: ti + j * width
+        for j in 0..min(blur_radius, width) {
+            let bb = backbuf[ti + j]; // VERTICAL: ti + j * width
             val_r += bb[0] as isize;
             val_g += bb[1] as isize;
             val_b += bb[2] as isize;
         }
+        if blur_radius > width {
+            val_r += (blur_radius - height) as isize * isize::from(lv[0]);
+            val_g += (blur_radius - height) as isize * isize::from(lv[1]);
+            val_b += (blur_radius - height) as isize * isize::from(lv[2]);
+        }
+
 
         // Process the left side where we need pixels from beyond the left edge
         for _ in 0..min(width, blur_radius + 1) {

--- a/src/blur.rs
+++ b/src/blur.rs
@@ -66,9 +66,9 @@ fn box_blur_vert(backbuf: &[[u8;3]], frontbuf: &mut [[u8;3]], width: usize, heig
         let fv: [u8;3] = backbuf[col_start];
         let lv: [u8;3] = backbuf[col_end];
 
-        let mut val_r: isize = (blur_radius as isize + 1) * (fv[0] as isize);
-        let mut val_g: isize = (blur_radius as isize + 1) * (fv[1] as isize);
-        let mut val_b: isize = (blur_radius as isize + 1) * (fv[2] as isize);
+        let mut val_r: isize = (blur_radius as isize + 1) * isize::from(fv[0]);
+        let mut val_g: isize = (blur_radius as isize + 1) * isize::from(fv[1]);
+        let mut val_b: isize = (blur_radius as isize + 1) * isize::from(fv[2]);
 
         // Get the pixel at the specified index, or the first pixel of the column
         // if the index is beyond the top edge of the image
@@ -92,9 +92,9 @@ fn box_blur_vert(backbuf: &[[u8;3]], frontbuf: &mut [[u8;3]], width: usize, heig
 
         for j in 0..min(blur_radius, height) {
             let bb = backbuf[ti + j * width];
-            val_r += bb[0] as isize;
-            val_g += bb[1] as isize;
-            val_b += bb[2] as isize;
+            val_r += isize::from(bb[0]);
+            val_g += isize::from(bb[1]);
+            val_b += isize::from(bb[2]);
         }
         if blur_radius > height {
             val_r += (blur_radius - height) as isize * isize::from(lv[0]);
@@ -104,9 +104,9 @@ fn box_blur_vert(backbuf: &[[u8;3]], frontbuf: &mut [[u8;3]], width: usize, heig
 
         for _ in 0..min(height, blur_radius + 1) {
             let bb = get_bottom(ri); ri += width;
-            val_r += bb[0] as isize - fv[0] as isize;
-            val_g += bb[1] as isize - fv[1] as isize;
-            val_b += bb[2] as isize - fv[2] as isize;
+            val_r += isize::from(bb[0]) - isize::from(fv[0]);
+            val_g += isize::from(bb[1]) - isize::from(fv[1]);
+            val_b += isize::from(bb[2]) - isize::from(fv[2]);
 
             frontbuf[ti] = [round(val_r as f32 * iarr) as u8,
                             round(val_g as f32 * iarr) as u8,
@@ -120,9 +120,9 @@ fn box_blur_vert(backbuf: &[[u8;3]], frontbuf: &mut [[u8;3]], width: usize, heig
                 let bb1 = backbuf[ri]; ri += width;
                 let bb2 = backbuf[li]; li += width;
 
-                val_r += bb1[0] as isize - bb2[0] as isize;
-                val_g += bb1[1] as isize - bb2[1] as isize;
-                val_b += bb1[2] as isize - bb2[2] as isize;
+                val_r += isize::from(bb1[0]) - isize::from(bb2[0]);
+                val_g += isize::from(bb1[1]) - isize::from(bb2[1]);
+                val_b += isize::from(bb1[2]) - isize::from(bb2[2]);
 
                 frontbuf[ti] = [round(val_r as f32 * iarr) as u8,
                                 round(val_g as f32 * iarr) as u8,
@@ -133,9 +133,9 @@ fn box_blur_vert(backbuf: &[[u8;3]], frontbuf: &mut [[u8;3]], width: usize, heig
             for _ in 0..min(height - blur_radius - 1, blur_radius) {
                 let bb = get_top(li); li += width;
 
-                val_r += lv[0] as isize - bb[0] as isize;
-                val_g += lv[1] as isize - bb[1] as isize;
-                val_b += lv[2] as isize - bb[2] as isize;
+                val_r += isize::from(lv[0]) - isize::from(bb[0]);
+                val_g += isize::from(lv[1]) - isize::from(bb[1]);
+                val_b += isize::from(lv[2]) - isize::from(bb[2]);
 
                 frontbuf[ti] = [round(val_r as f32 * iarr) as u8,
                                 round(val_g as f32 * iarr) as u8,
@@ -162,9 +162,9 @@ fn box_blur_horz(backbuf: &[[u8;3]], frontbuf: &mut [[u8;3]], width: usize, heig
         let fv: [u8;3] = backbuf[row_start];
         let lv: [u8;3] = backbuf[row_end]; // VERTICAL: $backbuf[ti + $width - 1];
 
-        let mut val_r: isize = (blur_radius as isize + 1) * (fv[0] as isize);
-        let mut val_g: isize = (blur_radius as isize + 1) * (fv[1] as isize);
-        let mut val_b: isize = (blur_radius as isize + 1) * (fv[2] as isize);
+        let mut val_r: isize = (blur_radius as isize + 1) * isize::from(fv[0]);
+        let mut val_g: isize = (blur_radius as isize + 1) * isize::from(fv[1]);
+        let mut val_b: isize = (blur_radius as isize + 1) * isize::from(fv[2]);
 
         // Get the pixel at the specified index, or the first pixel of the row
         // if the index is beyond the left edge of the image
@@ -188,9 +188,9 @@ fn box_blur_horz(backbuf: &[[u8;3]], frontbuf: &mut [[u8;3]], width: usize, heig
 
         for j in 0..min(blur_radius, width) {
             let bb = backbuf[ti + j]; // VERTICAL: ti + j * width
-            val_r += bb[0] as isize;
-            val_g += bb[1] as isize;
-            val_b += bb[2] as isize;
+            val_r += isize::from(bb[0]);
+            val_g += isize::from(bb[1]);
+            val_b += isize::from(bb[2]);
         }
         if blur_radius > width {
             val_r += (blur_radius - height) as isize * isize::from(lv[0]);
@@ -202,9 +202,9 @@ fn box_blur_horz(backbuf: &[[u8;3]], frontbuf: &mut [[u8;3]], width: usize, heig
         // Process the left side where we need pixels from beyond the left edge
         for _ in 0..min(width, blur_radius + 1) {
             let bb = get_right(ri); ri += 1;
-            val_r += bb[0] as isize - fv[0] as isize;
-            val_g += bb[1] as isize - fv[1] as isize;
-            val_b += bb[2] as isize - fv[2] as isize;
+            val_r += isize::from(bb[0]) - isize::from(fv[0]);
+            val_g += isize::from(bb[1]) - isize::from(fv[1]);
+            val_b += isize::from(bb[2]) - isize::from(fv[2]);
 
             frontbuf[ti] = [round(val_r as f32 * iarr) as u8,
                             round(val_g as f32 * iarr) as u8,
@@ -220,9 +220,9 @@ fn box_blur_horz(backbuf: &[[u8;3]], frontbuf: &mut [[u8;3]], width: usize, heig
                 let bb1 = backbuf[ri]; ri += 1;
                 let bb2 = backbuf[li]; li += 1;
 
-                val_r += bb1[0] as isize - bb2[0] as isize;
-                val_g += bb1[1] as isize - bb2[1] as isize;
-                val_b += bb1[2] as isize - bb2[2] as isize;
+                val_r += isize::from(bb1[0]) - isize::from(bb2[0]);
+                val_g += isize::from(bb1[1]) - isize::from(bb2[1]);
+                val_b += isize::from(bb1[2]) - isize::from(bb2[2]);
 
                 frontbuf[ti] = [round(val_r as f32 * iarr) as u8,
                                 round(val_g as f32 * iarr) as u8,
@@ -234,9 +234,9 @@ fn box_blur_horz(backbuf: &[[u8;3]], frontbuf: &mut [[u8;3]], width: usize, heig
             for _ in 0..min(width - blur_radius - 1, blur_radius) {
                 let bb = get_left(li); li += 1;
 
-                val_r += lv[0] as isize - bb[0] as isize;
-                val_g += lv[1] as isize - bb[1] as isize;
-                val_b += lv[2] as isize - bb[2] as isize;
+                val_r += isize::from(lv[0]) - isize::from(bb[0]);
+                val_g += isize::from(lv[1]) - isize::from(bb[1]);
+                val_b += isize::from(lv[2]) - isize::from(bb[2]);
 
                 frontbuf[ti] = [round(val_r as f32 * iarr) as u8,
                                 round(val_g as f32 * iarr) as u8,

--- a/src/blur.rs
+++ b/src/blur.rs
@@ -1,3 +1,5 @@
+use std::cmp::min;
+
 pub fn gaussian_blur(data: &mut Vec<[u8;3]>, width: usize, height: usize, blur_radius: f32)
 {
     let bxs = create_box_gauss(blur_radius, 3);
@@ -55,26 +57,49 @@ fn box_blur_vert(backbuf: &[[u8;3]], frontbuf: &mut [[u8;3]], width: usize, heig
 
     for i in 0..width {
 
+        let col_start = i; //inclusive
+        let col_end = i + width * (height - 1); //inclusive
         let mut ti: usize = i;
         let mut li: usize = ti;
         let mut ri: usize = ti + blur_radius * width;
 
-        let fv: [u8;3] = backbuf[ti];
-        let lv: [u8;3] = backbuf[ti + width * (height - 1)];
+        let fv: [u8;3] = backbuf[col_start];
+        let lv: [u8;3] = backbuf[col_end];
 
         let mut val_r: isize = (blur_radius as isize + 1) * (fv[0] as isize);
         let mut val_g: isize = (blur_radius as isize + 1) * (fv[1] as isize);
         let mut val_b: isize = (blur_radius as isize + 1) * (fv[2] as isize);
 
+        // Get the pixel at the specified index, or the first pixel of the column
+        // if the index is beyond the top edge of the image
+        let get_top = |i: usize| {
+            if i < col_start {
+                fv
+            } else {
+                backbuf[i]
+            }
+        };
+
+        // Get the pixel at the specified index, or the last pixel of the column
+        // if the index is beyond the bottom edge of the image
+        let get_bottom = |i: usize| {
+            if i > col_end {
+                lv
+            } else {
+                backbuf[i]
+            }
+        };
+
+        // TODO: not linear complexity, fix this
         for j in 0..blur_radius {
-            let bb = backbuf[ti + j * width];
+            let bb = get_bottom(ti + j * width);
             val_r += bb[0] as isize;
             val_g += bb[1] as isize;
             val_b += bb[2] as isize;
         }
 
-        for _ in 0..(blur_radius + 1) {
-            let bb = backbuf[ri]; ri += width;
+        for _ in 0..min(height, blur_radius + 1) {
+            let bb = get_bottom(ri); ri += width;
             val_r += bb[0] as isize - fv[0] as isize;
             val_g += bb[1] as isize - fv[1] as isize;
             val_b += bb[2] as isize - fv[2] as isize;
@@ -85,32 +110,34 @@ fn box_blur_vert(backbuf: &[[u8;3]], frontbuf: &mut [[u8;3]], width: usize, heig
             ti += width;
         }
 
-        for _ in (blur_radius + 1)..(height - blur_radius) {
+        if height > blur_radius { // otherwise `(height - blur_radius)` will underflow
+            for _ in (blur_radius + 1)..(height - blur_radius) {
 
-            let bb1 = backbuf[ri]; ri += width;
-            let bb2 = backbuf[li]; li += width;
+                let bb1 = backbuf[ri]; ri += width;
+                let bb2 = backbuf[li]; li += width;
 
-            val_r += bb1[0] as isize - bb2[0] as isize;
-            val_g += bb1[1] as isize - bb2[1] as isize;
-            val_b += bb1[2] as isize - bb2[2] as isize;
+                val_r += bb1[0] as isize - bb2[0] as isize;
+                val_g += bb1[1] as isize - bb2[1] as isize;
+                val_b += bb1[2] as isize - bb2[2] as isize;
 
-            frontbuf[ti] = [round(val_r as f32 * iarr) as u8,
-                            round(val_g as f32 * iarr) as u8,
-                            round(val_b as f32 * iarr) as u8];
-            ti += width;
-        }
+                frontbuf[ti] = [round(val_r as f32 * iarr) as u8,
+                                round(val_g as f32 * iarr) as u8,
+                                round(val_b as f32 * iarr) as u8];
+                ti += width;
+            }
 
-        for _ in (height - blur_radius)..height {
-            let bb = backbuf[li]; li += width;
+            for _ in 0..min(height - blur_radius - 1, blur_radius) {
+                let bb = get_bottom(li); li += width;
 
-            val_r += lv[0] as isize - bb[0] as isize;
-            val_g += lv[1] as isize - bb[1] as isize;
-            val_b += lv[2] as isize - bb[2] as isize;
+                val_r += lv[0] as isize - bb[0] as isize;
+                val_g += lv[1] as isize - bb[1] as isize;
+                val_b += lv[2] as isize - bb[2] as isize;
 
-            frontbuf[ti] = [round(val_r as f32 * iarr) as u8,
-                            round(val_g as f32 * iarr) as u8,
-                            round(val_b as f32 * iarr) as u8];
-            ti += width;
+                frontbuf[ti] = [round(val_r as f32 * iarr) as u8,
+                                round(val_g as f32 * iarr) as u8,
+                                round(val_b as f32 * iarr) as u8];
+                ti += width;
+            }
         }
     }
 }
@@ -122,26 +149,50 @@ fn box_blur_horz(backbuf: &[[u8;3]], frontbuf: &mut [[u8;3]], width: usize, heig
 
     for i in 0..height {
 
+        let row_start: usize = i * width; // inclusive
+        let row_end: usize = (i + 1) * width - 1; // inclusive
         let mut ti: usize = i * width; // VERTICAL: $i;
         let mut li: usize = ti;
         let mut ri: usize = ti + blur_radius;
 
-        let fv: [u8;3] = backbuf[ti];
-        let lv: [u8;3] = backbuf[ti + width - 1]; // VERTICAL: $backbuf[ti + $width - 1];
+        let fv: [u8;3] = backbuf[row_start];
+        let lv: [u8;3] = backbuf[row_end]; // VERTICAL: $backbuf[ti + $width - 1];
 
         let mut val_r: isize = (blur_radius as isize + 1) * (fv[0] as isize);
         let mut val_g: isize = (blur_radius as isize + 1) * (fv[1] as isize);
         let mut val_b: isize = (blur_radius as isize + 1) * (fv[2] as isize);
 
+        // Get the pixel at the specified index, or the first pixel of the row
+        // if the index is beyond the left edge of the image
+        let get_left = |i: usize| {
+            if i < row_start {
+                fv
+            } else {
+                backbuf[i]
+            }
+        };
+
+        // Get the pixel at the specified index, or the last pixel of the row
+        // if the index is beyond the right edge of the image
+        let get_right = |i: usize| {
+            if i > row_end {
+                lv
+            } else {
+                backbuf[i]
+            }
+        };
+
+        // TODO: not linear complexity, fix this
         for j in 0..blur_radius {
-            let bb = backbuf[ti + j]; // VERTICAL: ti + j * width
+            let bb = get_right(ti + j); // VERTICAL: ti + j * width
             val_r += bb[0] as isize;
             val_g += bb[1] as isize;
             val_b += bb[2] as isize;
         }
 
-        for _ in 0..(blur_radius + 1) {
-            let bb = backbuf[ri]; ri += 1;
+        // Process the left side where we need pixels from beyond the left edge
+        for _ in 0..min(width, blur_radius + 1) {
+            let bb = get_right(ri); ri += 1;
             val_r += bb[0] as isize - fv[0] as isize;
             val_g += bb[1] as isize - fv[1] as isize;
             val_b += bb[2] as isize - fv[2] as isize;
@@ -152,32 +203,37 @@ fn box_blur_horz(backbuf: &[[u8;3]], frontbuf: &mut [[u8;3]], width: usize, heig
             ti += 1; // VERTICAL : ti += width, same with the other areas
         }
 
-        for _ in (blur_radius + 1)..(width - blur_radius) {
+        if width > blur_radius { // otherwise `(width - blur_radius)` will underflow
+            // Process the middle where we know we won't bump into borders
+            // without the extra indirection of get_left/get_right. This is faster.
+            for _ in (blur_radius + 1)..(width - blur_radius) {
 
-            let bb1 = backbuf[ri]; ri += 1;
-            let bb2 = backbuf[li]; li += 1;
+                let bb1 = backbuf[ri]; ri += 1;
+                let bb2 = backbuf[li]; li += 1;
 
-            val_r += bb1[0] as isize - bb2[0] as isize;
-            val_g += bb1[1] as isize - bb2[1] as isize;
-            val_b += bb1[2] as isize - bb2[2] as isize;
+                val_r += bb1[0] as isize - bb2[0] as isize;
+                val_g += bb1[1] as isize - bb2[1] as isize;
+                val_b += bb1[2] as isize - bb2[2] as isize;
 
-            frontbuf[ti] = [round(val_r as f32 * iarr) as u8,
-                            round(val_g as f32 * iarr) as u8,
-                            round(val_b as f32 * iarr) as u8];
-            ti += 1;
-        }
+                frontbuf[ti] = [round(val_r as f32 * iarr) as u8,
+                                round(val_g as f32 * iarr) as u8,
+                                round(val_b as f32 * iarr) as u8];
+                ti += 1;
+            }
 
-        for _ in (width - blur_radius)..width {
-            let bb = backbuf[li]; li += 1;
+            // Process the right side where we need pixels from beyond the right edge
+            for _ in 0..min(width - blur_radius - 1, blur_radius) {
+                let bb = get_left(li); li += 1;
 
-            val_r += lv[0] as isize - bb[0] as isize;
-            val_g += lv[1] as isize - bb[1] as isize;
-            val_b += lv[2] as isize - bb[2] as isize;
+                val_r += lv[0] as isize - bb[0] as isize;
+                val_g += lv[1] as isize - bb[1] as isize;
+                val_b += lv[2] as isize - bb[2] as isize;
 
-            frontbuf[ti] = [round(val_r as f32 * iarr) as u8,
-                            round(val_g as f32 * iarr) as u8,
-                            round(val_b as f32 * iarr) as u8];
-            ti += 1;
+                frontbuf[ti] = [round(val_r as f32 * iarr) as u8,
+                                round(val_g as f32 * iarr) as u8,
+                                round(val_b as f32 * iarr) as u8];
+                ti += 1;
+            }
         }
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -82,6 +82,8 @@ fn test_large_blur_doesnt_panic() {
         gaussian_blur(&mut data_new, width as usize, height as usize, 180.0); // smaller than height
         gaussian_blur(&mut data_new, width as usize, height as usize, 500.0); // bigger than height, smaller than width
         gaussian_blur(&mut data_new, width as usize, height as usize, 500000.0); // bigger than both
+        // causes panic in debug mode due to integer overflow, works in release mode
+        // gaussian_blur(&mut data_new, width as usize, height as usize, 500000000000000000.0); // ridiculously big
     } else {
         panic!("could not decode png");
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -56,3 +56,33 @@ fn test_blur_image_correctly() {
         panic!("could not decode png");
     }
 }
+
+#[test]
+fn test_large_blur_doesnt_panic() {
+    extern crate image;
+
+    use super::gaussian_blur;
+    use super::utils;
+
+    let image_bytes = include_bytes!("../assets/cballs.png");
+
+    let res1 = image::load_from_memory_with_format(image_bytes, image::ImageFormat::PNG);
+    if let Ok(image::DynamicImage::ImageRgb8(png_data)) = res1 {
+        let width = png_data.width() as usize;
+        let height = png_data.height() as usize;
+        let data = png_data.into_raw();
+        let mut data_new = Vec::<[u8;3]>::with_capacity(width * height);
+        data_new.resize(width * height, [0, 0, 0]);
+        for y in 0..height {
+            for x in 0..width {
+                let offset = ((width * y) + x) as usize;
+                data_new[((width * y) + x) as usize] = [data[offset * 3], data[(offset * 3) + 1], data[(offset * 3) + 2]];
+            }
+        }
+        gaussian_blur(&mut data_new, width as usize, height as usize, 180.0); // smaller than height
+        gaussian_blur(&mut data_new, width as usize, height as usize, 500.0); // bigger than height, smaller than width
+        gaussian_blur(&mut data_new, width as usize, height as usize, 500000.0); // bigger than both
+    } else {
+        panic!("could not decode png");
+    }
+}


### PR DESCRIPTION
Correctly handle blur radius larger than the image size. Fixes #4

Ridiculously large blur radius still causes a panic on overflow in debug mode, but not in release mode.

Sadly this regresses benchmarks from 3.6ms to 3.8ms, but correctness is more important